### PR TITLE
Update DevFest data for turlock

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -10951,7 +10951,7 @@
   },
   {
     "slug": "turlock",
-    "destinationUrl": "https://gdg.community.dev/gdg-turlock/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-modesto-presents-devfest-2025/cohost-gdg-turlock",
     "gdgChapter": "GDG Turlock",
     "city": "Turlock",
     "countryName": "United States",
@@ -10959,10 +10959,10 @@
     "latitude": 37.4945743,
     "longitude": -120.8459786,
     "gdgUrl": "https://gdg.community.dev/gdg-turlock/",
-    "devfestName": "DevFest Turlock 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest 2025",
+    "devfestDate": "2025-10-25",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.690Z"
+    "updatedAt": "2025-04-21T10:54:06.715Z"
   },
   {
     "slug": "uberaba",


### PR DESCRIPTION
This PR updates the DevFest data for `turlock` based on issue #21.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-modesto-presents-devfest-2025/cohost-gdg-turlock",
  "gdgChapter": "GDG Turlock",
  "city": "Turlock",
  "countryName": "United States",
  "countryCode": "US",
  "latitude": 37.4945743,
  "longitude": -120.8459786,
  "gdgUrl": "https://gdg.community.dev/gdg-turlock/",
  "devfestName": "DevFest 2025",
  "devfestDate": "2025-10-25",
  "updatedBy": "choraria",
  "updatedAt": "2025-04-21T10:54:06.715Z"
}
```

_Note: This branch will be automatically deleted after merging._