### PR TITLE
Update DevFest data for cluj-napoca

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -2671,7 +2671,7 @@
   },
   {
     "slug": "cluj-napoca",
-    "destinationUrl": "https://gdg.community.dev/gdg-cluj-napoca/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-on-campus-babes-bolyai-university-cluj-napoca-romania-presents-devfest-cluj-napoca-2025/",
     "gdgChapter": "GDG Cluj-Napoca",
     "city": "Cluj-Napoca",
     "countryName": "Romania",
@@ -2680,9 +2680,9 @@
     "longitude": 23.59,
     "gdgUrl": "https://gdg.community.dev/gdg-cluj-napoca/",
     "devfestName": "DevFest Cluj-Napoca 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-03-01",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.684Z"
+    "updatedAt": "2025-06-13T07:43:24.675Z"
   },
   {
     "slug": "coast-lebanon",


### PR DESCRIPTION
This PR updates the DevFest data for `cluj-napoca` based on issue #34.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-on-campus-babes-bolyai-university-cluj-napoca-romania-presents-devfest-cluj-napoca-2025/",
  "gdgChapter": "GDG Cluj-Napoca",
  "city": "Cluj-Napoca",
  "countryName": "Romania",
  "countryCode": "RO",
  "latitude": 46.78,
  "longitude": 23.59,
  "gdgUrl": "https://gdg.community.dev/gdg-cluj-napoca/",
  "devfestName": "DevFest Cluj-Napoca 2025",
  "devfestDate": "2025-03-01",
  "updatedBy": "choraria",
  "updatedAt": "2025-06-13T07:43:24.675Z"
}
```

_Note: This branch will be automatically deleted after merging._