### PR TITLE
Update DevFest data for athens

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -796,7 +796,7 @@
   },
   {
     "slug": "athens",
-    "destinationUrl": "https://gdg.community.dev/gdg-athens/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-athens-presents-devfest-2025/",
     "gdgChapter": "GDG Athens",
     "city": "Athens",
     "countryName": "Greece",
@@ -804,10 +804,10 @@
     "latitude": 37.98,
     "longitude": 23.73,
     "gdgUrl": "https://gdg.community.dev/gdg-athens/",
-    "devfestName": "DevFest Athens 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest 2025",
+    "devfestDate": "2025-11-01",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.682Z"
+    "updatedAt": "2025-07-27T23:23:42.104Z"
   },
   {
     "slug": "athlone",


### PR DESCRIPTION
This PR updates the DevFest data for `athens` based on issue #64.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-athens-presents-devfest-2025/",
  "gdgChapter": "GDG Athens",
  "city": "Athens",
  "countryName": "Greece",
  "countryCode": "GR",
  "latitude": 37.98,
  "longitude": 23.73,
  "gdgUrl": "https://gdg.community.dev/gdg-athens/",
  "devfestName": "DevFest 2025",
  "devfestDate": "2025-11-01",
  "updatedBy": "choraria",
  "updatedAt": "2025-07-27T23:23:42.104Z"
}
```

_Note: This branch will be automatically deleted after merging._