### PR TITLE
Update DevFest data for galway

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -3886,7 +3886,7 @@
   },
   {
     "slug": "galway",
-    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-portlaoise-presents-devfest-ireland-2025/cohost-gdg-portlaoise",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-portlaoise-presents-devfest-ireland-2025/cohost-gdg-galway",
     "gdgChapter": "GDG Galway",
     "city": "Galway",
     "countryName": "Ireland",
@@ -3897,7 +3897,7 @@
     "devfestName": "DevFest Ireland 2025",
     "devfestDate": "2025-12-06",
     "updatedBy": "choraria",
-    "updatedAt": "2025-07-30T07:07:41.480Z"
+    "updatedAt": "2025-07-30T07:10:12.065Z"
   },
   {
     "slug": "gandhinagar",


### PR DESCRIPTION
This PR updates the DevFest data for `galway` based on issue #70.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-portlaoise-presents-devfest-ireland-2025/cohost-gdg-galway",
  "gdgChapter": "GDG Galway",
  "city": "Galway",
  "countryName": "Ireland",
  "countryCode": "IE",
  "latitude": 53.28,
  "longitude": -9.06,
  "gdgUrl": "https://gdg.community.dev/gdg-galway/",
  "devfestName": "DevFest Ireland 2025",
  "devfestDate": "2025-12-06",
  "updatedBy": "choraria",
  "updatedAt": "2025-07-30T07:10:12.065Z"
}
```

_Note: This branch will be automatically deleted after merging._