### PR TITLE
Update DevFest data for dublin

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -3331,7 +3331,7 @@
   },
   {
     "slug": "dublin",
-    "destinationUrl": "https://gdg.community.dev/gdg-dublin/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-portlaoise-presents-devfest-ireland-2025/cohost-gdg-dublin",
     "gdgChapter": "GDG Dublin",
     "city": "Dublin",
     "countryName": "Ireland",
@@ -3339,10 +3339,10 @@
     "latitude": 53.33,
     "longitude": -6.25,
     "gdgUrl": "https://gdg.community.dev/gdg-dublin/",
-    "devfestName": "DevFest Dublin 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest Ireland 2025",
+    "devfestDate": "2025-12-06",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.684Z"
+    "updatedAt": "2025-07-30T07:11:10.953Z"
   },
   {
     "slug": "durgapur",


### PR DESCRIPTION
This PR updates the DevFest data for `dublin` based on issue #71.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-portlaoise-presents-devfest-ireland-2025/cohost-gdg-dublin",
  "gdgChapter": "GDG Dublin",
  "city": "Dublin",
  "countryName": "Ireland",
  "countryCode": "IE",
  "latitude": 53.33,
  "longitude": -6.25,
  "gdgUrl": "https://gdg.community.dev/gdg-dublin/",
  "devfestName": "DevFest Ireland 2025",
  "devfestDate": "2025-12-06",
  "updatedBy": "choraria",
  "updatedAt": "2025-07-30T07:11:10.953Z"
}
```

_Note: This branch will be automatically deleted after merging._