### PR TITLE
Update DevFest data for burgos

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -1981,7 +1981,7 @@
   },
   {
     "slug": "burgos",
-    "destinationUrl": "https://gdg.community.dev/gdg-burgos/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-burgos-presents-morcillaconf-2025-devfest-burgos/",
     "gdgChapter": "GDG Burgos",
     "city": "Burgos",
     "countryName": "Spain",
@@ -1989,10 +1989,10 @@
     "latitude": 42.35,
     "longitude": -3.69,
     "gdgUrl": "https://gdg.community.dev/gdg-burgos/",
-    "devfestName": "DevFest Burgos 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "MorcillaConf 2025 - DevFest Burgos",
+    "devfestDate": "2025-09-26",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.683Z"
+    "updatedAt": "2025-08-01T23:30:43.533Z"
   },
   {
     "slug": "burnaby",


### PR DESCRIPTION
This PR updates the DevFest data for `burgos` based on issue #84.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-burgos-presents-morcillaconf-2025-devfest-burgos/",
  "gdgChapter": "GDG Burgos",
  "city": "Burgos",
  "countryName": "Spain",
  "countryCode": "ES",
  "latitude": 42.35,
  "longitude": -3.69,
  "gdgUrl": "https://gdg.community.dev/gdg-burgos/",
  "devfestName": "MorcillaConf 2025 - DevFest Burgos",
  "devfestDate": "2025-09-26",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-01T23:30:43.533Z"
}
```

_Note: This branch will be automatically deleted after merging._