### PR TITLE
Update DevFest data for lecce

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -6076,7 +6076,7 @@
   },
   {
     "slug": "lecce",
-    "destinationUrl": "https://gdg.community.dev/gdg-lecce/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-lecce-presents-devfest-lecce-2025/",
     "gdgChapter": "GDG Lecce",
     "city": "Lecce",
     "countryName": "Italy",
@@ -6085,9 +6085,9 @@
     "longitude": 18.174966,
     "gdgUrl": "https://gdg.community.dev/gdg-lecce/",
     "devfestName": "DevFest Lecce 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-09-13",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.686Z"
+    "updatedAt": "2025-08-01T23:45:53.113Z"
   },
   {
     "slug": "leeds",


### PR DESCRIPTION
This PR updates the DevFest data for `lecce` based on issue #98.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-lecce-presents-devfest-lecce-2025/",
  "gdgChapter": "GDG Lecce",
  "city": "Lecce",
  "countryName": "Italy",
  "countryCode": "IT",
  "latitude": 40.3515255,
  "longitude": 18.174966,
  "gdgUrl": "https://gdg.community.dev/gdg-lecce/",
  "devfestName": "DevFest Lecce 2025",
  "devfestDate": "2025-09-13",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-01T23:45:53.113Z"
}
```

_Note: This branch will be automatically deleted after merging._