### PR TITLE
Update DevFest data for mauritius

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -7006,7 +7006,7 @@
   },
   {
     "slug": "mauritius",
-    "destinationUrl": "https://gdg.community.dev/gdg-mauritius/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-mauritius-presents-devfest-mauritius-2025/",
     "gdgChapter": "GDG Mauritius",
     "city": "Flic en Flac",
     "countryName": "Mauritius",
@@ -7014,10 +7014,10 @@
     "latitude": -20.27,
     "longitude": 57.37,
     "gdgUrl": "https://gdg.community.dev/gdg-mauritius/",
-    "devfestName": "DevFest Flic en Flac 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest Mauritius 2025",
+    "devfestDate": "2025-10-04",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.687Z"
+    "updatedAt": "2025-08-01T23:56:59.967Z"
   },
   {
     "slug": "mbale",


### PR DESCRIPTION
This PR updates the DevFest data for `mauritius` based on issue #108.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-mauritius-presents-devfest-mauritius-2025/",
  "gdgChapter": "GDG Mauritius",
  "city": "Flic en Flac",
  "countryName": "Mauritius",
  "countryCode": "MU",
  "latitude": -20.27,
  "longitude": 57.37,
  "gdgUrl": "https://gdg.community.dev/gdg-mauritius/",
  "devfestName": "DevFest Mauritius 2025",
  "devfestDate": "2025-10-04",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-01T23:56:59.967Z"
}
```

_Note: This branch will be automatically deleted after merging._