### PR TITLE
Update DevFest data for yaounde

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -11641,7 +11641,7 @@
   },
   {
     "slug": "yaounde",
-    "destinationUrl": "https://gdg.community.dev/gdg-yaounde/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-yaounde-presents-devfest-yaounde-2025/cohost-gdg-yaounde",
     "gdgChapter": "GDG Yaoundé",
     "city": "Yaounde",
     "countryName": "Cameroon",
@@ -11649,10 +11649,10 @@
     "latitude": 3.87,
     "longitude": 11.52,
     "gdgUrl": "https://gdg.community.dev/gdg-yaounde/",
-    "devfestName": "DevFest Yaounde 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest Yaoundé 2025",
+    "devfestDate": "2025-10-04",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.690Z"
+    "updatedAt": "2025-08-01T23:58:07.664Z"
   },
   {
     "slug": "yenagoa",


### PR DESCRIPTION
This PR updates the DevFest data for `yaounde` based on issue #110.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-yaounde-presents-devfest-yaounde-2025/cohost-gdg-yaounde",
  "gdgChapter": "GDG Yaoundé",
  "city": "Yaounde",
  "countryName": "Cameroon",
  "countryCode": "CM",
  "latitude": 3.87,
  "longitude": 11.52,
  "gdgUrl": "https://gdg.community.dev/gdg-yaounde/",
  "devfestName": "DevFest Yaoundé 2025",
  "devfestDate": "2025-10-04",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-01T23:58:07.664Z"
}
```

_Note: This branch will be automatically deleted after merging._