### PR TITLE
Update DevFest data for lyon

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -6556,7 +6556,7 @@
   },
   {
     "slug": "lyon",
-    "destinationUrl": "https://gdg.community.dev/gdg-lyon/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-lyon-presents-devfest-lyon-premiere-edition-1/",
     "gdgChapter": "GDG Lyon",
     "city": "Lyon",
     "countryName": "France",
@@ -6564,10 +6564,10 @@
     "latitude": 45.76,
     "longitude": 4.83,
     "gdgUrl": "https://gdg.community.dev/gdg-lyon/",
-    "devfestName": "DevFest Lyon 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest Lyon - Première édition 🦁",
+    "devfestDate": "2025-11-28",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.686Z"
+    "updatedAt": "2025-08-02T00:06:18.764Z"
   },
   {
     "slug": "maceio",


### PR DESCRIPTION
This PR updates the DevFest data for `lyon` based on issue #114.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-lyon-presents-devfest-lyon-premiere-edition-1/",
  "gdgChapter": "GDG Lyon",
  "city": "Lyon",
  "countryName": "France",
  "countryCode": "FR",
  "latitude": 45.76,
  "longitude": 4.83,
  "gdgUrl": "https://gdg.community.dev/gdg-lyon/",
  "devfestName": "DevFest Lyon - Première édition 🦁",
  "devfestDate": "2025-11-28",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-02T00:06:18.764Z"
}
```

_Note: This branch will be automatically deleted after merging._