### PR TITLE
Update DevFest data for seattle

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -9736,7 +9736,7 @@
   },
   {
     "slug": "seattle",
-    "destinationUrl": "https://gdg.community.dev/gdg-seattle/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-seattle-presents-devfest-seattle-2025/",
     "gdgChapter": "GDG Seattle",
     "city": "Seattle",
     "countryName": "United States",
@@ -9745,9 +9745,9 @@
     "longitude": -122.33,
     "gdgUrl": "https://gdg.community.dev/gdg-seattle/",
     "devfestName": "DevFest Seattle 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-11-18",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.689Z"
+    "updatedAt": "2025-08-14T05:53:21.189Z"
   },
   {
     "slug": "semarang",


### PR DESCRIPTION
This PR updates the DevFest data for `seattle` based on issue #126.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-seattle-presents-devfest-seattle-2025/",
  "gdgChapter": "GDG Seattle",
  "city": "Seattle",
  "countryName": "United States",
  "countryCode": "US",
  "latitude": 47.6,
  "longitude": -122.33,
  "gdgUrl": "https://gdg.community.dev/gdg-seattle/",
  "devfestName": "DevFest Seattle 2025",
  "devfestDate": "2025-11-18",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-14T05:53:21.189Z"
}
```

_Note: This branch will be automatically deleted after merging._