### PR TITLE
Update DevFest data for akure

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -406,7 +406,7 @@
   },
   {
     "slug": "akure",
-    "destinationUrl": "https://gdg.community.dev/gdg-akure/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-akure-presents-devfest-akure-2025/",
     "gdgChapter": "GDG Akure",
     "city": "Akure",
     "countryName": "Nigeria",
@@ -415,9 +415,9 @@
     "longitude": 5.2057909,
     "gdgUrl": "https://gdg.community.dev/gdg-akure/",
     "devfestName": "DevFest Akure 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-12-05",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.682Z"
+    "updatedAt": "2025-08-15T17:17:42.290Z"
   },
   {
     "slug": "albuquerque",


### PR DESCRIPTION
This PR updates the DevFest data for `akure` based on issue #132.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-akure-presents-devfest-akure-2025/",
  "gdgChapter": "GDG Akure",
  "city": "Akure",
  "countryName": "Nigeria",
  "countryCode": "NG",
  "latitude": 7.2571325,
  "longitude": 5.2057909,
  "gdgUrl": "https://gdg.community.dev/gdg-akure/",
  "devfestName": "DevFest Akure 2025",
  "devfestDate": "2025-12-05",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-15T17:17:42.290Z"
}
```

_Note: This branch will be automatically deleted after merging._