### PR TITLE
Update DevFest data for owerri

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -8236,7 +8236,7 @@
   },
   {
     "slug": "owerri",
-    "destinationUrl": "https://gdg.community.dev/gdg-owerri/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-owerri-presents-devfest-owerri-2025-innovate-and-thrive-building-the-future-with-ai-and-beyond/",
     "gdgChapter": "GDG Owerri",
     "city": "Owerri",
     "countryName": "Nigeria",
@@ -8244,10 +8244,10 @@
     "latitude": 5.5,
     "longitude": 7.02,
     "gdgUrl": "https://gdg.community.dev/gdg-owerri/",
-    "devfestName": "DevFest Owerri 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "Devfest Owerri 2025: Innovate and Thrive - Building the Future with AI and Beyond",
+    "devfestDate": "2025-11-08",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.688Z"
+    "updatedAt": "2025-08-15T17:20:49.416Z"
   },
   {
     "slug": "oxford",


### PR DESCRIPTION
This PR updates the DevFest data for `owerri` based on issue #134.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-owerri-presents-devfest-owerri-2025-innovate-and-thrive-building-the-future-with-ai-and-beyond/",
  "gdgChapter": "GDG Owerri",
  "city": "Owerri",
  "countryName": "Nigeria",
  "countryCode": "NG",
  "latitude": 5.5,
  "longitude": 7.02,
  "gdgUrl": "https://gdg.community.dev/gdg-owerri/",
  "devfestName": "Devfest Owerri 2025: Innovate and Thrive - Building the Future with AI and Beyond",
  "devfestDate": "2025-11-08",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-15T17:20:49.416Z"
}
```

_Note: This branch will be automatically deleted after merging._