### PR TITLE
Update DevFest data for abuja

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -121,7 +121,7 @@
   },
   {
     "slug": "abuja",
-    "destinationUrl": "https://gdg.community.dev/gdg-abuja/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-abuja-presents-devfest-abuja-2025/",
     "gdgChapter": "GDG Abuja",
     "city": "Abuja",
     "countryName": "Nigeria",
@@ -130,9 +130,9 @@
     "longitude": 7.17,
     "gdgUrl": "https://gdg.community.dev/gdg-abuja/",
     "devfestName": "DevFest Abuja 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-11-29",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.682Z"
+    "updatedAt": "2025-08-16T08:39:56.678Z"
   },
   {
     "slug": "acapulco",


### PR DESCRIPTION
This PR updates the DevFest data for `abuja` based on issue #144.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-abuja-presents-devfest-abuja-2025/",
  "gdgChapter": "GDG Abuja",
  "city": "Abuja",
  "countryName": "Nigeria",
  "countryCode": "NG",
  "latitude": 9.18,
  "longitude": 7.17,
  "gdgUrl": "https://gdg.community.dev/gdg-abuja/",
  "devfestName": "DevFest Abuja 2025",
  "devfestDate": "2025-11-29",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-16T08:39:56.678Z"
}
```

_Note: This branch will be automatically deleted after merging._