### PR TITLE
Update DevFest data for faro

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -3661,7 +3661,7 @@
   },
   {
     "slug": "faro",
-    "destinationUrl": "https://gdg.community.dev/gdg-faro/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-faro-presents-devfest-2025-by-gdg-faro/",
     "gdgChapter": "GDG Faro",
     "city": "Faro",
     "countryName": "Portugal",
@@ -3669,10 +3669,10 @@
     "latitude": 37.03,
     "longitude": -7.94,
     "gdgUrl": "https://gdg.community.dev/gdg-faro/",
-    "devfestName": "DevFest Faro 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest 2025 by GDG Faro",
+    "devfestDate": "2025-11-21",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.684Z"
+    "updatedAt": "2025-08-17T12:34:24.328Z"
   },
   {
     "slug": "finistere",


### PR DESCRIPTION
This PR updates the DevFest data for `faro` based on issue #154.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-faro-presents-devfest-2025-by-gdg-faro/",
  "gdgChapter": "GDG Faro",
  "city": "Faro",
  "countryName": "Portugal",
  "countryCode": "PT",
  "latitude": 37.03,
  "longitude": -7.94,
  "gdgUrl": "https://gdg.community.dev/gdg-faro/",
  "devfestName": "DevFest 2025 by GDG Faro",
  "devfestDate": "2025-11-21",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-17T12:34:24.328Z"
}
```

_Note: This branch will be automatically deleted after merging._