### PR TITLE
Update DevFest data for sevilla

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -9811,7 +9811,7 @@
   },
   {
     "slug": "sevilla",
-    "destinationUrl": "https://gdg.community.dev/gdg-sevilla/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-sevilla-presents-devfest-sevilla-2025/",
     "gdgChapter": "GDG Sevilla",
     "city": "Seville",
     "countryName": "Spain",
@@ -9819,10 +9819,10 @@
     "latitude": 37.4,
     "longitude": -5.98,
     "gdgUrl": "https://gdg.community.dev/gdg-sevilla/",
-    "devfestName": "DevFest Seville 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "Devfest Sevilla 2025",
+    "devfestDate": "2025-11-09",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.689Z"
+    "updatedAt": "2025-08-17T12:37:08.476Z"
   },
   {
     "slug": "sfax",


### PR DESCRIPTION
This PR updates the DevFest data for `sevilla` based on issue #156.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-sevilla-presents-devfest-sevilla-2025/",
  "gdgChapter": "GDG Sevilla",
  "city": "Seville",
  "countryName": "Spain",
  "countryCode": "ES",
  "latitude": 37.4,
  "longitude": -5.98,
  "gdgUrl": "https://gdg.community.dev/gdg-sevilla/",
  "devfestName": "Devfest Sevilla 2025",
  "devfestDate": "2025-11-09",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-17T12:37:08.476Z"
}
```

_Note: This branch will be automatically deleted after merging._