### PR TITLE
Update DevFest data for jaen

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -5011,7 +5011,7 @@
   },
   {
     "slug": "jaen",
-    "destinationUrl": "https://gdg.community.dev/gdg-jaen/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-jaen-presents-devfest-2025/",
     "gdgChapter": "GDG Jaén",
     "city": "Jaen",
     "countryName": "Spain",
@@ -5019,10 +5019,10 @@
     "latitude": 37.77,
     "longitude": -3.8,
     "gdgUrl": "https://gdg.community.dev/gdg-jaen/",
-    "devfestName": "DevFest Jaen 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest 2025",
+    "devfestDate": "2025-11-22",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.685Z"
+    "updatedAt": "2025-08-17T12:39:08.970Z"
   },
   {
     "slug": "jaipur",


### PR DESCRIPTION
This PR updates the DevFest data for `jaen` based on issue #158.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-jaen-presents-devfest-2025/",
  "gdgChapter": "GDG Jaén",
  "city": "Jaen",
  "countryName": "Spain",
  "countryCode": "ES",
  "latitude": 37.77,
  "longitude": -3.8,
  "gdgUrl": "https://gdg.community.dev/gdg-jaen/",
  "devfestName": "DevFest 2025",
  "devfestDate": "2025-11-22",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-17T12:39:08.970Z"
}
```

_Note: This branch will be automatically deleted after merging._