### PR TITLE
Update DevFest data for abakaliki

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -46,7 +46,7 @@
   },
   {
     "slug": "abakaliki",
-    "destinationUrl": "https://gdg.community.dev/gdg-abakaliki/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-abakaliki-presents-devfest-abakaliki-2025/",
     "gdgChapter": "GDG Abakaliki",
     "city": "Abakaliki",
     "countryName": "Nigeria",
@@ -54,10 +54,10 @@
     "latitude": 6.3230608,
     "longitude": 8.1120116,
     "gdgUrl": "https://gdg.community.dev/gdg-abakaliki/",
-    "devfestName": "DevFest Abakaliki 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "Devfest Abakaliki 2025",
+    "devfestDate": "2025-10-11",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.682Z"
+    "updatedAt": "2025-08-17T12:47:51.938Z"
   },
   {
     "slug": "abc",


### PR DESCRIPTION
This PR updates the DevFest data for `abakaliki` based on issue #160.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-abakaliki-presents-devfest-abakaliki-2025/",
  "gdgChapter": "GDG Abakaliki",
  "city": "Abakaliki",
  "countryName": "Nigeria",
  "countryCode": "NG",
  "latitude": 6.3230608,
  "longitude": 8.1120116,
  "gdgUrl": "https://gdg.community.dev/gdg-abakaliki/",
  "devfestName": "Devfest Abakaliki 2025",
  "devfestDate": "2025-10-11",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-17T12:47:51.938Z"
}
```

_Note: This branch will be automatically deleted after merging._