### PR TITLE
Update DevFest data for minna

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -7201,7 +7201,7 @@
   },
   {
     "slug": "minna",
-    "destinationUrl": "https://gdg.community.dev/gdg-minna/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-minna-presents-devfest-minna-2025/cohost-gdg-minna",
     "gdgChapter": "GDG Minna",
     "city": "Minna",
     "countryName": "Nigeria",
@@ -7210,9 +7210,9 @@
     "longitude": 6.55,
     "gdgUrl": "https://gdg.community.dev/gdg-minna/",
     "devfestName": "DevFest Minna 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-11-08",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.687Z"
+    "updatedAt": "2025-08-19T05:29:14.855Z"
   },
   {
     "slug": "minneapolis",


### PR DESCRIPTION
This PR updates the DevFest data for `minna` based on issue #176.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-minna-presents-devfest-minna-2025/cohost-gdg-minna",
  "gdgChapter": "GDG Minna",
  "city": "Minna",
  "countryName": "Nigeria",
  "countryCode": "NG",
  "latitude": 9.6,
  "longitude": 6.55,
  "gdgUrl": "https://gdg.community.dev/gdg-minna/",
  "devfestName": "DevFest Minna 2025",
  "devfestDate": "2025-11-08",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-19T05:29:14.855Z"
}
```

_Note: This branch will be automatically deleted after merging._