### PR TITLE
Update DevFest data for bandung

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -1036,7 +1036,7 @@
   },
   {
     "slug": "bandung",
-    "destinationUrl": "https://gdg.community.dev/gdg-bandung/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-bandung-presents-road-to-devfest-bandung-2025-build-faster-launch-smarter-with-firebase-studio-web-and-cloud/",
     "gdgChapter": "GDG Bandung",
     "city": "Bandung",
     "countryName": "Indonesia",
@@ -1044,10 +1044,10 @@
     "latitude": -6.91,
     "longitude": 107.6,
     "gdgUrl": "https://gdg.community.dev/gdg-bandung/",
-    "devfestName": "DevFest Bandung 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "Road To DevFest Bandung 2025: Build Faster, Launch Smarter With Firebase Studio, Web, and Cloud",
+    "devfestDate": "2025-08-23",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.683Z"
+    "updatedAt": "2025-08-19T12:44:27.379Z"
   },
   {
     "slug": "bangalore",


### PR DESCRIPTION
This PR updates the DevFest data for `bandung` based on issue #180.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-bandung-presents-road-to-devfest-bandung-2025-build-faster-launch-smarter-with-firebase-studio-web-and-cloud/",
  "gdgChapter": "GDG Bandung",
  "city": "Bandung",
  "countryName": "Indonesia",
  "countryCode": "ID",
  "latitude": -6.91,
  "longitude": 107.6,
  "gdgUrl": "https://gdg.community.dev/gdg-bandung/",
  "devfestName": "Road To DevFest Bandung 2025: Build Faster, Launch Smarter With Firebase Studio, Web, and Cloud",
  "devfestDate": "2025-08-23",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-19T12:44:27.379Z"
}
```

_Note: This branch will be automatically deleted after merging._