### PR TITLE
Update DevFest data for fresno

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -3781,7 +3781,7 @@
   },
   {
     "slug": "fresno",
-    "destinationUrl": "https://gdg.community.dev/gdg-fresno/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-fresno-presents-devfest-fresno-build-with-ai/",
     "gdgChapter": "GDG Fresno",
     "city": "Fresno",
     "countryName": "United States",
@@ -3789,10 +3789,10 @@
     "latitude": 36.8,
     "longitude": -119.88,
     "gdgUrl": "https://gdg.community.dev/gdg-fresno/",
-    "devfestName": "DevFest Fresno 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest Fresno - Build with AI",
+    "devfestDate": "2025-10-18",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.684Z"
+    "updatedAt": "2025-08-20T05:18:06.467Z"
   },
   {
     "slug": "frisco",


### PR DESCRIPTION
This PR updates the DevFest data for `fresno` based on issue #184.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-fresno-presents-devfest-fresno-build-with-ai/",
  "gdgChapter": "GDG Fresno",
  "city": "Fresno",
  "countryName": "United States",
  "countryCode": "US",
  "latitude": 36.8,
  "longitude": -119.88,
  "gdgUrl": "https://gdg.community.dev/gdg-fresno/",
  "devfestName": "DevFest Fresno - Build with AI",
  "devfestDate": "2025-10-18",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-20T05:18:06.467Z"
}
```

_Note: This branch will be automatically deleted after merging._