### PR TITLE
Update DevFest data for elazig

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -3526,7 +3526,7 @@
   },
   {
     "slug": "elazig",
-    "destinationUrl": "https://gdg.community.dev/gdg-elazig/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-elazig-presents-devfest-elazig25/",
     "gdgChapter": "GDG Elazığ",
     "city": "Elazig",
     "countryName": "Turkey",
@@ -3534,10 +3534,10 @@
     "latitude": 38.68,
     "longitude": 39.23,
     "gdgUrl": "https://gdg.community.dev/gdg-elazig/",
-    "devfestName": "DevFest Elazig 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest Elazig'25",
+    "devfestDate": "2025-11-21",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.684Z"
+    "updatedAt": "2025-08-21T06:12:18.262Z"
   },
   {
     "slug": "elbayadh",


### PR DESCRIPTION
This PR updates the DevFest data for `elazig` based on issue #188.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-elazig-presents-devfest-elazig25/",
  "gdgChapter": "GDG Elazığ",
  "city": "Elazig",
  "countryName": "Turkey",
  "countryCode": "TR",
  "latitude": 38.68,
  "longitude": 39.23,
  "gdgUrl": "https://gdg.community.dev/gdg-elazig/",
  "devfestName": "DevFest Elazig'25",
  "devfestDate": "2025-11-21",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-21T06:12:18.262Z"
}
```

_Note: This branch will be automatically deleted after merging._