### PR TITLE
Update DevFest data for ibadan

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -4726,7 +4726,7 @@
   },
   {
     "slug": "ibadan",
-    "destinationUrl": "https://gdg.community.dev/gdg-ibadan/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-ibadan-presents-devfest-ibadan-2025-1/",
     "gdgChapter": "GDG Ibadan",
     "city": "Ibadan",
     "countryName": "Nigeria",
@@ -4735,9 +4735,9 @@
     "longitude": 3.93,
     "gdgUrl": "https://gdg.community.dev/gdg-ibadan/",
     "devfestName": "DevFest Ibadan 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-11-29",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.685Z"
+    "updatedAt": "2025-08-22T05:40:53.889Z"
   },
   {
     "slug": "ibanda",


### PR DESCRIPTION
This PR updates the DevFest data for `ibadan` based on issue #203.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-ibadan-presents-devfest-ibadan-2025-1/",
  "gdgChapter": "GDG Ibadan",
  "city": "Ibadan",
  "countryName": "Nigeria",
  "countryCode": "NG",
  "latitude": 7.38,
  "longitude": 3.93,
  "gdgUrl": "https://gdg.community.dev/gdg-ibadan/",
  "devfestName": "DevFest Ibadan 2025",
  "devfestDate": "2025-11-29",
  "updatedBy": "choraria",
  "updatedAt": "2025-08-22T05:40:53.889Z"
}
```

_Note: This branch will be automatically deleted after merging._