### PR TITLE
Update DevFest data for taipei

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -10486,7 +10486,7 @@
   },
   {
     "slug": "taipei",
-    "destinationUrl": "https://gdg.community.dev/gdg-taipei/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-taipei-presents-devfest-taipei-2025/cohost-gdg-taipei",
     "gdgChapter": "GDG Taipei",
     "city": "Taipei",
     "countryName": "Taiwan",
@@ -10495,9 +10495,9 @@
     "longitude": 121.45,
     "gdgUrl": "https://gdg.community.dev/gdg-taipei/",
     "devfestName": "DevFest Taipei 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-12-06",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.689Z"
+    "updatedAt": "2025-09-02T05:04:25.418Z"
   },
   {
     "slug": "taldykorgan",


### PR DESCRIPTION
This PR updates the DevFest data for `taipei` based on issue #233.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-taipei-presents-devfest-taipei-2025/cohost-gdg-taipei",
  "gdgChapter": "GDG Taipei",
  "city": "Taipei",
  "countryName": "Taiwan",
  "countryCode": "TW",
  "latitude": 25.02,
  "longitude": 121.45,
  "gdgUrl": "https://gdg.community.dev/gdg-taipei/",
  "devfestName": "DevFest Taipei 2025",
  "devfestDate": "2025-12-06",
  "updatedBy": "choraria",
  "updatedAt": "2025-09-02T05:04:25.418Z"
}
```

_Note: This branch will be automatically deleted after merging._