### PR TITLE
Update DevFest data for kisii

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -5596,7 +5596,7 @@
   },
   {
     "slug": "kisii",
-    "destinationUrl": "https://gdg.community.dev/gdg-kisii/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-kisii-presents-devfest-kisii-2025/",
     "gdgChapter": "GDG Kisii",
     "city": "Kisii",
     "countryName": "Kenya",
@@ -5605,9 +5605,9 @@
     "longitude": 34.76,
     "gdgUrl": "https://gdg.community.dev/gdg-kisii/",
     "devfestName": "DevFest Kisii 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-11-15",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.686Z"
+    "updatedAt": "2025-09-04T15:35:42.596Z"
   },
   {
     "slug": "kisumu",


### PR DESCRIPTION
This PR updates the DevFest data for `kisii` based on issue #241.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-kisii-presents-devfest-kisii-2025/",
  "gdgChapter": "GDG Kisii",
  "city": "Kisii",
  "countryName": "Kenya",
  "countryCode": "KE",
  "latitude": -0.67,
  "longitude": 34.76,
  "gdgUrl": "https://gdg.community.dev/gdg-kisii/",
  "devfestName": "DevFest Kisii 2025",
  "devfestDate": "2025-11-15",
  "updatedBy": "choraria",
  "updatedAt": "2025-09-04T15:35:42.596Z"
}
```

_Note: This branch will be automatically deleted after merging._