### PR TITLE
Update DevFest data for singapore

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -10021,7 +10021,7 @@
   },
   {
     "slug": "singapore",
-    "destinationUrl": "https://gdg.community.dev/gdg-singapore/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-singapore-presents-devfest-singapore-2025/",
     "gdgChapter": "GDG Singapore",
     "city": "Singapore",
     "countryName": "Singapore",
@@ -10030,9 +10030,9 @@
     "longitude": 103.85,
     "gdgUrl": "https://gdg.community.dev/gdg-singapore/",
     "devfestName": "DevFest Singapore 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-11-22",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.689Z"
+    "updatedAt": "2025-09-06T09:10:57.816Z"
   },
   {
     "slug": "sinop",


### PR DESCRIPTION
This PR updates the DevFest data for `singapore` based on issue #243.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-singapore-presents-devfest-singapore-2025/",
  "gdgChapter": "GDG Singapore",
  "city": "Singapore",
  "countryName": "Singapore",
  "countryCode": "SG",
  "latitude": 1.3,
  "longitude": 103.85,
  "gdgUrl": "https://gdg.community.dev/gdg-singapore/",
  "devfestName": "DevFest Singapore 2025",
  "devfestDate": "2025-11-22",
  "updatedBy": "choraria",
  "updatedAt": "2025-09-06T09:10:57.816Z"
}
```

_Note: This branch will be automatically deleted after merging._