### PR TITLE
Update DevFest data for jalingo

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -5071,7 +5071,7 @@
   },
   {
     "slug": "jalingo",
-    "destinationUrl": "https://gdg.community.dev/gdg-jalingo/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-jalingo-presents-devfest-jalingo-2025/",
     "gdgChapter": "GDG Jalingo",
     "city": "Jalingo",
     "countryName": "Nigeria",
@@ -5080,9 +5080,9 @@
     "longitude": 11.37,
     "gdgUrl": "https://gdg.community.dev/gdg-jalingo/",
     "devfestName": "DevFest Jalingo 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-10-04",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.685Z"
+    "updatedAt": "2025-09-07T17:23:39.703Z"
   },
   {
     "slug": "jammu",


### PR DESCRIPTION
This PR updates the DevFest data for `jalingo` based on issue #247.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-jalingo-presents-devfest-jalingo-2025/",
  "gdgChapter": "GDG Jalingo",
  "city": "Jalingo",
  "countryName": "Nigeria",
  "countryCode": "NG",
  "latitude": 8.89,
  "longitude": 11.37,
  "gdgUrl": "https://gdg.community.dev/gdg-jalingo/",
  "devfestName": "DevFest Jalingo 2025",
  "devfestDate": "2025-10-04",
  "updatedBy": "choraria",
  "updatedAt": "2025-09-07T17:23:39.703Z"
}
```

_Note: This branch will be automatically deleted after merging._