### PR TITLE
Update DevFest data for mersin

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -7111,7 +7111,7 @@
   },
   {
     "slug": "mersin",
-    "destinationUrl": "https://gdg.community.dev/gdg-mersin/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-mersin-presents-devfest-mersin-2025/",
     "gdgChapter": "GDG Mersin",
     "city": "Mersin",
     "countryName": "Turkey",
@@ -7120,9 +7120,9 @@
     "longitude": 34.63,
     "gdgUrl": "https://gdg.community.dev/gdg-mersin/",
     "devfestName": "DevFest Mersin 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-12-06",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.687Z"
+    "updatedAt": "2025-09-11T07:25:43.948Z"
   },
   {
     "slug": "miage-gi",


### PR DESCRIPTION
This PR updates the DevFest data for `mersin` based on issue #267.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-mersin-presents-devfest-mersin-2025/",
  "gdgChapter": "GDG Mersin",
  "city": "Mersin",
  "countryName": "Turkey",
  "countryCode": "TR",
  "latitude": 36.81,
  "longitude": 34.63,
  "gdgUrl": "https://gdg.community.dev/gdg-mersin/",
  "devfestName": "DevFest Mersin 2025",
  "devfestDate": "2025-12-06",
  "updatedBy": "choraria",
  "updatedAt": "2025-09-11T07:25:43.948Z"
}
```

_Note: This branch will be automatically deleted after merging._