### PR TITLE
Update DevFest data for antalya

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -601,7 +601,7 @@
   },
   {
     "slug": "antalya",
-    "destinationUrl": "https://gdg.community.dev/gdg-antalya/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-antalya-presents-devfest25-antalya-kickoff/",
     "gdgChapter": "GDG Antalya",
     "city": "Antalya",
     "countryName": "Turkey",
@@ -609,10 +609,10 @@
     "latitude": 36.89,
     "longitude": 30.71,
     "gdgUrl": "https://gdg.community.dev/gdg-antalya/",
-    "devfestName": "DevFest Antalya 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest'25 Antalya Kickoff",
+    "devfestDate": "2025-12-05",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.682Z"
+    "updatedAt": "2025-09-17T06:36:17.676Z"
   },
   {
     "slug": "antananarivo",


### PR DESCRIPTION
This PR updates the DevFest data for `antalya` based on issue #285.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-antalya-presents-devfest25-antalya-kickoff/",
  "gdgChapter": "GDG Antalya",
  "city": "Antalya",
  "countryName": "Turkey",
  "countryCode": "TR",
  "latitude": 36.89,
  "longitude": 30.71,
  "gdgUrl": "https://gdg.community.dev/gdg-antalya/",
  "devfestName": "DevFest'25 Antalya Kickoff",
  "devfestDate": "2025-12-05",
  "updatedBy": "choraria",
  "updatedAt": "2025-09-17T06:36:17.676Z"
}
```

_Note: This branch will be automatically deleted after merging._