### PR TITLE
Update DevFest data for surrey

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -10396,7 +10396,7 @@
   },
   {
     "slug": "surrey",
-    "destinationUrl": "https://gdg.community.dev/gdg-surrey/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-surrey-presents-gdg-surrey-devfest-2025-virtual-series-ai-is-now-built-in-your-browser-update-2025-10-08/cohost-gdg-surrey",
     "gdgChapter": "GDG Surrey",
     "city": "Surrey",
     "countryName": "Canada",
@@ -10404,10 +10404,10 @@
     "latitude": 49.1913466,
     "longitude": -122.8490125,
     "gdgUrl": "https://gdg.community.dev/gdg-surrey/",
-    "devfestName": "DevFest Surrey 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "GDG Surrey DevFest 2025 Virtual Series- AI is now built IN your browser (Update)",
+    "devfestDate": "2025-10-09",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.689Z"
+    "updatedAt": "2025-09-21T06:16:58.760Z"
   },
   {
     "slug": "suzhou",


### PR DESCRIPTION
This PR updates the DevFest data for `surrey` based on issue #309.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-surrey-presents-gdg-surrey-devfest-2025-virtual-series-ai-is-now-built-in-your-browser-update-2025-10-08/cohost-gdg-surrey",
  "gdgChapter": "GDG Surrey",
  "city": "Surrey",
  "countryName": "Canada",
  "countryCode": "CA",
  "latitude": 49.1913466,
  "longitude": -122.8490125,
  "gdgUrl": "https://gdg.community.dev/gdg-surrey/",
  "devfestName": "GDG Surrey DevFest 2025 Virtual Series- AI is now built IN your browser (Update)",
  "devfestDate": "2025-10-09",
  "updatedBy": "choraria",
  "updatedAt": "2025-09-21T06:16:58.760Z"
}
```

_Note: This branch will be automatically deleted after merging._