### PR TITLE
Update DevFest data for brisbane

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -1741,7 +1741,7 @@
   },
   {
     "slug": "brisbane",
-    "destinationUrl": "https://gdg.community.dev/gdg-brisbane/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-brisbane-presents-gdg-brisbane-devfest-2025/",
     "gdgChapter": "GDG Brisbane",
     "city": "Brisbane",
     "countryName": "Australia",
@@ -1749,10 +1749,10 @@
     "latitude": -27.46,
     "longitude": 153.02,
     "gdgUrl": "https://gdg.community.dev/gdg-brisbane/",
-    "devfestName": "DevFest Brisbane 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "GDG Brisbane DevFest 2025",
+    "devfestDate": "2025-10-25",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.683Z"
+    "updatedAt": "2025-09-23T09:18:59.334Z"
   },
   {
     "slug": "bronx",


### PR DESCRIPTION
This PR updates the DevFest data for `brisbane` based on issue #323.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-brisbane-presents-gdg-brisbane-devfest-2025/",
  "gdgChapter": "GDG Brisbane",
  "city": "Brisbane",
  "countryName": "Australia",
  "countryCode": "AU",
  "latitude": -27.46,
  "longitude": 153.02,
  "gdgUrl": "https://gdg.community.dev/gdg-brisbane/",
  "devfestName": "GDG Brisbane DevFest 2025",
  "devfestDate": "2025-10-25",
  "updatedBy": "choraria",
  "updatedAt": "2025-09-23T09:18:59.334Z"
}
```

_Note: This branch will be automatically deleted after merging._