### PR TITLE
Update DevFest data for kigali

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -5551,7 +5551,7 @@
   },
   {
     "slug": "kigali",
-    "destinationUrl": "https://gdg.community.dev/gdg-kigali/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-kigali-presents-devfest-kigali-2025/",
     "gdgChapter": "GDG Kigali",
     "city": "Kigali",
     "countryName": "Rwanda",
@@ -5559,10 +5559,10 @@
     "latitude": -1.94,
     "longitude": 30.06,
     "gdgUrl": "https://gdg.community.dev/gdg-kigali/",
-    "devfestName": "DevFest Kigali 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "Devfest Kigali 2025",
+    "devfestDate": "2025-12-19",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.686Z"
+    "updatedAt": "2025-09-25T10:05:45.447Z"
   },
   {
     "slug": "kinshasa",


### PR DESCRIPTION
This PR updates the DevFest data for `kigali` based on issue #327.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-kigali-presents-devfest-kigali-2025/",
  "gdgChapter": "GDG Kigali",
  "city": "Kigali",
  "countryName": "Rwanda",
  "countryCode": "RW",
  "latitude": -1.94,
  "longitude": 30.06,
  "gdgUrl": "https://gdg.community.dev/gdg-kigali/",
  "devfestName": "Devfest Kigali 2025",
  "devfestDate": "2025-12-19",
  "updatedBy": "choraria",
  "updatedAt": "2025-09-25T10:05:45.447Z"
}
```

_Note: This branch will be automatically deleted after merging._