### PR TITLE
Update DevFest data for stuttgart

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -10321,7 +10321,7 @@
   },
   {
     "slug": "stuttgart",
-    "destinationUrl": "https://gdg.community.dev/gdg-stuttgart/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-stuttgart-presents-devfest-2025-stuttgart-exploring-cloud-innovations/",
     "gdgChapter": "GDG Stuttgart",
     "city": "Stuttgart",
     "countryName": "Germany",
@@ -10329,10 +10329,10 @@
     "latitude": 48.7758459,
     "longitude": 9.1829321,
     "gdgUrl": "https://gdg.community.dev/gdg-stuttgart/",
-    "devfestName": "DevFest Stuttgart 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest 2025 Stuttgart: Exploring Cloud Innovations",
+    "devfestDate": "2025-10-21",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.689Z"
+    "updatedAt": "2025-10-01T16:43:51.140Z"
   },
   {
     "slug": "sucre",


### PR DESCRIPTION
This PR updates the DevFest data for `stuttgart` based on issue #343.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-stuttgart-presents-devfest-2025-stuttgart-exploring-cloud-innovations/",
  "gdgChapter": "GDG Stuttgart",
  "city": "Stuttgart",
  "countryName": "Germany",
  "countryCode": "DE",
  "latitude": 48.7758459,
  "longitude": 9.1829321,
  "gdgUrl": "https://gdg.community.dev/gdg-stuttgart/",
  "devfestName": "DevFest 2025 Stuttgart: Exploring Cloud Innovations",
  "devfestDate": "2025-10-21",
  "updatedBy": "choraria",
  "updatedAt": "2025-10-01T16:43:51.140Z"
}
```

_Note: This branch will be automatically deleted after merging._