### PR TITLE
Update DevFest data for jammu

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -5086,7 +5086,7 @@
   },
   {
     "slug": "jammu",
-    "destinationUrl": "https://gdg.community.dev/gdg-jammu/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-jammu-presents-devfest-jammu-2025/",
     "gdgChapter": "GDG Jammu",
     "city": "Jammu",
     "countryName": "India",
@@ -5094,10 +5094,10 @@
     "latitude": 32.7266016,
     "longitude": 74.8570259,
     "gdgUrl": "https://gdg.community.dev/gdg-jammu/",
-    "devfestName": "DevFest Jammu 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "Devfest Jammu 2025",
+    "devfestDate": "2025-11-02",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.685Z"
+    "updatedAt": "2025-10-02T10:05:44.628Z"
   },
   {
     "slug": "jeju",


### PR DESCRIPTION
This PR updates the DevFest data for `jammu` based on issue #351.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-jammu-presents-devfest-jammu-2025/",
  "gdgChapter": "GDG Jammu",
  "city": "Jammu",
  "countryName": "India",
  "countryCode": "IN",
  "latitude": 32.7266016,
  "longitude": 74.8570259,
  "gdgUrl": "https://gdg.community.dev/gdg-jammu/",
  "devfestName": "Devfest Jammu 2025",
  "devfestDate": "2025-11-02",
  "updatedBy": "choraria",
  "updatedAt": "2025-10-02T10:05:44.628Z"
}
```

_Note: This branch will be automatically deleted after merging._