### PR TITLE
Update DevFest data for kaduna-city

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -5260,9 +5260,9 @@
     "longitude": 7.44,
     "gdgUrl": "https://gdg.community.dev/gdg-kaduna-city/",
     "devfestName": "DevFest Kaduna 2025",
-    "devfestDate": "2025-10-24",
+    "devfestDate": "2025-10-18",
     "updatedBy": "choraria",
-    "updatedAt": "2025-07-30T17:23:26.740Z"
+    "updatedAt": "2025-10-05T19:05:23.915Z"
   },
   {
     "slug": "kafanchan",


### PR DESCRIPTION
This PR updates the DevFest data for `kaduna-city` based on issue #368.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-kaduna-city-presents-devfest-kaduna-2025/cohost-gdg-kaduna-city",
  "gdgChapter": "GDG Kaduna City",
  "city": "Kaduna",
  "countryName": "Nigeria",
  "countryCode": "NG",
  "latitude": 10.52,
  "longitude": 7.44,
  "gdgUrl": "https://gdg.community.dev/gdg-kaduna-city/",
  "devfestName": "DevFest Kaduna 2025",
  "devfestDate": "2025-10-18",
  "updatedBy": "choraria",
  "updatedAt": "2025-10-05T19:05:23.915Z"
}
```

_Note: This branch will be automatically deleted after merging._