### PR TITLE
Update DevFest data for lauro-de-freitas

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -6031,7 +6031,7 @@
   },
   {
     "slug": "lauro-de-freitas",
-    "destinationUrl": "https://gdg.community.dev/gdg-lauro-de-freitas/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-lauro-de-freitas-presents-devfest-lauro-de-freitas-2025/",
     "gdgChapter": "GDG Lauro de Freitas",
     "city": "Lauro de Freitas",
     "countryName": "Brazil",
@@ -6040,9 +6040,9 @@
     "longitude": -38.3084506,
     "gdgUrl": "https://gdg.community.dev/gdg-lauro-de-freitas/",
     "devfestName": "DevFest Lauro de Freitas 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-11-29",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33.686Z"
+    "updatedAt": "2025-10-06T13:48:49.487Z"
   },
   {
     "slug": "lawrence",


### PR DESCRIPTION
This PR updates the DevFest data for `lauro-de-freitas` based on issue #386.

**Changes:**
```json
{
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-lauro-de-freitas-presents-devfest-lauro-de-freitas-2025/",
  "gdgChapter": "GDG Lauro de Freitas",
  "city": "Lauro de Freitas",
  "countryName": "Brazil",
  "countryCode": "BR",
  "latitude": -12.8848712,
  "longitude": -38.3084506,
  "gdgUrl": "https://gdg.community.dev/gdg-lauro-de-freitas/",
  "devfestName": "DevFest Lauro de Freitas 2025",
  "devfestDate": "2025-11-29",
  "updatedBy": "choraria",
  "updatedAt": "2025-10-06T13:48:49.487Z"
}
```

_Note: This branch will be automatically deleted after merging._