### PR TITLE
Update DevFest data for mientrung

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -6822,7 +6822,7 @@
     "devfestName": "GDG Devfest MienTrung 2025: Vibe coding Workshop",
     "devfestDate": "2025-10-18",
     "updatedBy": "choraria",
-    "updatedAt": "2025-10-09T14:48:12Z"
+    "updatedAt": "2025-10-09T15:52:23.837Z"
   },
   {
     "slug": "milano",


### PR DESCRIPTION
This PR updates the DevFest data for `mientrung` based on issue #415.

**Changes:**
```json
{
  "slug": "mientrung",
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-mientrung-presents-gdg-devfest-mientrung-2025-vibe-coding-workshop/",
  "gdgChapter": "GDG MienTrung",
  "city": "Da Nang",
  "countryName": "Viet Nam",
  "countryCode": "VN",
  "latitude": 16.07,
  "longitude": 108.21,
  "gdgUrl": "https://gdg.community.dev/gdg-mientrung/",
  "devfestName": "GDG Devfest MienTrung 2025: Vibe coding Workshop",
  "devfestDate": "2025-10-18",
  "updatedBy": "choraria",
  "updatedAt": "2025-10-09T15:52:23.837Z"
}
```

_Note: This branch will be automatically deleted after merging._