### PR TITLE
Update DevFest data for kathmandu

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -5176,7 +5176,7 @@
   },
   {
     "slug": "kathmandu",
-    "destinationUrl": "https://gdg.community.dev/gdg-kathmandu/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-kathmandu-presents-devfest-kathmandu-2025/",
     "gdgChapter": "GDG Kathmandu",
     "city": "Kathmandu",
     "countryName": "Nepal",
@@ -5185,9 +5185,9 @@
     "longitude": 85.31,
     "gdgUrl": "https://gdg.community.dev/gdg-kathmandu/",
     "devfestName": "DevFest Kathmandu 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-12-06",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33Z"
+    "updatedAt": "2025-10-10T12:49:08.778Z"
   },
   {
     "slug": "katsina",


### PR DESCRIPTION
This PR updates the DevFest data for `kathmandu` based on issue #417.

**Changes:**
```json
{
  "slug": "kathmandu",
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-kathmandu-presents-devfest-kathmandu-2025/",
  "gdgChapter": "GDG Kathmandu",
  "city": "Kathmandu",
  "countryName": "Nepal",
  "countryCode": "NP",
  "latitude": 27.71,
  "longitude": 85.31,
  "gdgUrl": "https://gdg.community.dev/gdg-kathmandu/",
  "devfestName": "DevFest Kathmandu 2025",
  "devfestDate": "2025-12-06",
  "updatedBy": "choraria",
  "updatedAt": "2025-10-10T12:49:08.778Z"
}
```

_Note: This branch will be automatically deleted after merging._