### PR TITLE
Update DevFest data for helwan

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -4321,7 +4321,7 @@
   },
   {
     "slug": "helwan",
-    "destinationUrl": "https://gdg.community.dev/gdg-helwan/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-helwan-presents-devfest25-gdg-helwan/",
     "gdgChapter": "GDG Helwan",
     "city": "Helwan",
     "countryName": "Egypt",
@@ -4329,10 +4329,10 @@
     "latitude": 29.85,
     "longitude": 31.34,
     "gdgUrl": "https://gdg.community.dev/gdg-helwan/",
-    "devfestName": "DevFest Helwan 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest'25 - GDG Helwan",
+    "devfestDate": "2025-11-18",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33Z"
+    "updatedAt": "2025-10-12T09:07:29.762Z"
   },
   {
     "slug": "heraklion",


### PR DESCRIPTION
This PR updates the DevFest data for `helwan` based on issue #420.

**Changes:**
```json
{
  "slug": "helwan",
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-helwan-presents-devfest25-gdg-helwan/",
  "gdgChapter": "GDG Helwan",
  "city": "Helwan",
  "countryName": "Egypt",
  "countryCode": "EG",
  "latitude": 29.85,
  "longitude": 31.34,
  "gdgUrl": "https://gdg.community.dev/gdg-helwan/",
  "devfestName": "DevFest'25 - GDG Helwan",
  "devfestDate": "2025-11-18",
  "updatedBy": "choraria",
  "updatedAt": "2025-10-12T09:07:29.762Z"
}
```

_Note: This branch will be automatically deleted after merging._