### PR TITLE
Update DevFest data for budapest

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -1846,7 +1846,7 @@
   },
   {
     "slug": "budapest",
-    "destinationUrl": "https://gdg.community.dev/gdg-budapest/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-budapest-presents-devfest-budapest-2025-the-ai-conference/",
     "gdgChapter": "GDG Budapest",
     "city": "Budapest",
     "countryName": "Hungary",
@@ -1854,10 +1854,10 @@
     "latitude": 47.51,
     "longitude": 19.08,
     "gdgUrl": "https://gdg.community.dev/gdg-budapest/",
-    "devfestName": "DevFest Budapest 2025",
-    "devfestDate": "2025-06-01",
+    "devfestName": "DevFest Budapest 2025 - The AI Conference",
+    "devfestDate": "2025-11-21",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33Z"
+    "updatedAt": "2025-10-20T06:49:19.811Z"
   },
   {
     "slug": "buea",


### PR DESCRIPTION
This PR updates the DevFest data for `budapest` based on issue #436.

**Changes:**
```json
{
  "slug": "budapest",
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-budapest-presents-devfest-budapest-2025-the-ai-conference/",
  "gdgChapter": "GDG Budapest",
  "city": "Budapest",
  "countryName": "Hungary",
  "countryCode": "HU",
  "latitude": 47.51,
  "longitude": 19.08,
  "gdgUrl": "https://gdg.community.dev/gdg-budapest/",
  "devfestName": "DevFest Budapest 2025 - The AI Conference",
  "devfestDate": "2025-11-21",
  "updatedBy": "choraria",
  "updatedAt": "2025-10-20T06:49:19.811Z"
}
```

_Note: This branch will be automatically deleted after merging._