### PR TITLE
Update DevFest data for kyiv

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -5611,7 +5611,7 @@
   },
   {
     "slug": "kyiv",
-    "destinationUrl": "https://gdg.community.dev/gdg-kyiv/",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-kyiv-presents-devfest-kyiv-2025/cohost-gdg-kyiv",
     "gdgChapter": "GDG Kyiv",
     "city": "Kyiv",
     "countryName": "Ukraine",
@@ -5620,9 +5620,9 @@
     "longitude": 30.5245025,
     "gdgUrl": "https://gdg.community.dev/gdg-kyiv/",
     "devfestName": "DevFest Kyiv 2025",
-    "devfestDate": "2025-06-01",
+    "devfestDate": "2025-11-22",
     "updatedBy": "choraria",
-    "updatedAt": "2025-04-16T20:11:33Z"
+    "updatedAt": "2025-10-20T06:51:13.995Z"
   },
   {
     "slug": "kyoto",


### PR DESCRIPTION
This PR updates the DevFest data for `kyiv` based on issue #438.

**Changes:**
```json
{
  "slug": "kyiv",
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-kyiv-presents-devfest-kyiv-2025/cohost-gdg-kyiv",
  "gdgChapter": "GDG Kyiv",
  "city": "Kyiv",
  "countryName": "Ukraine",
  "countryCode": "UA",
  "latitude": 50.4503596,
  "longitude": 30.5245025,
  "gdgUrl": "https://gdg.community.dev/gdg-kyiv/",
  "devfestName": "DevFest Kyiv 2025",
  "devfestDate": "2025-11-22",
  "updatedBy": "choraria",
  "updatedAt": "2025-10-20T06:51:13.995Z"
}
```

_Note: This branch will be automatically deleted after merging._