### PR TITLE
Update DevFest data for mons

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -8056,7 +8056,7 @@
   },
   {
     "slug": "mons",
-    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-brussels-presents-devfest-belgium-2025/cohost-gdg-mons",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-mons-presents-devfest-belgium-2026/",
     "gdgChapter": "GDG Mons",
     "city": "Mons",
     "countryName": "Belgium",
@@ -8064,10 +8064,10 @@
     "latitude": 50.4542408,
     "longitude": 3.956659,
     "gdgUrl": "https://gdg.community.dev/gdg-mons/",
-    "devfestName": "Devfest Belgium 2025",
-    "devfestDate": "2025-11-28",
+    "devfestName": "Devfest Belgium 2026",
+    "devfestDate": "2026-11-27",
     "updatedBy": "choraria",
-    "updatedAt": "2025-10-29T10:47:44Z"
+    "updatedAt": "2026-07-09T14:16:47.521Z"
   },
   {
     "slug": "monterrey",


### PR DESCRIPTION
This PR updates the DevFest data for `mons` based on issue #476.

**Changes:**
```json
{
  "slug": "mons",
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-mons-presents-devfest-belgium-2026/",
  "gdgChapter": "GDG Mons",
  "city": "Mons",
  "countryName": "Belgium",
  "countryCode": "BE",
  "latitude": 50.4542408,
  "longitude": 3.956659,
  "gdgUrl": "https://gdg.community.dev/gdg-mons/",
  "devfestName": "Devfest Belgium 2026",
  "devfestDate": "2026-11-27",
  "updatedBy": "choraria",
  "updatedAt": "2026-07-09T14:16:47.521Z"
}
```

> Maintainer: click **Approve** on this PR to publish. Auto-merge is enabled — no manual merge needed.