### PR TITLE
Update DevFest data for quito

### DIFF
--- a/data/devfest-data.json
+++ b/data/devfest-data.json
@@ -9916,7 +9916,7 @@
   },
   {
     "slug": "quito",
-    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-quito-presents-devfest-ecuador-2025/cohost-gdg-quito",
+    "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-quito-presents-devfest-2026-innovating-together/",
     "gdgChapter": "GDG Quito",
     "city": "Quito",
     "countryName": "Ecuador",
@@ -9924,10 +9924,10 @@
     "latitude": -0.1806532,
     "longitude": -78.4678382,
     "gdgUrl": "https://gdg.community.dev/gdg-quito/",
-    "devfestName": "Devfest Ecuador 2025",
-    "devfestDate": "2025-11-29",
+    "devfestName": "DevFest 2026: Innovating Together",
+    "devfestDate": "2026-09-26",
     "updatedBy": "choraria",
-    "updatedAt": "2025-10-29T10:47:44Z"
+    "updatedAt": "2026-07-09T14:18:16.196Z"
   },
   {
     "slug": "raipur",


### PR DESCRIPTION
This PR updates the DevFest data for `quito` based on issue #478.

**Changes:**
```json
{
  "slug": "quito",
  "destinationUrl": "https://gdg.community.dev/events/details/google-gdg-quito-presents-devfest-2026-innovating-together/",
  "gdgChapter": "GDG Quito",
  "city": "Quito",
  "countryName": "Ecuador",
  "countryCode": "EC",
  "latitude": -0.1806532,
  "longitude": -78.4678382,
  "gdgUrl": "https://gdg.community.dev/gdg-quito/",
  "devfestName": "DevFest 2026: Innovating Together",
  "devfestDate": "2026-09-26",
  "updatedBy": "choraria",
  "updatedAt": "2026-07-09T14:18:16.196Z"
}
```

> Maintainer: click **Approve** on this PR to publish. Auto-merge is enabled — no manual merge needed.